### PR TITLE
Use `prompt-cont` instead of `prompt2`

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ You may use it like this:
 ```haskell
 :set -package funnyprint
 
-:def color (\_ -> return (":set -interactive-print=FunnyPrint.funnyPrint\n:set prompt \"" ++ FunnyPrint.prompt "λ " "%s" " ¬\\nλ > " ++ "\"" ++ "\n:set prompt2 \"" ++ FunnyPrint.prompt2 "λ" "" " | " ++ "\""))
-:def nocolor (\_ -> return ":set -interactive-print=print\n:set prompt \"%s> \"\n:set prompt2 \"%s| \"")
+:def color (\_ -> return (":set -interactive-print=FunnyPrint.funnyPrint\n:set prompt \"" ++ FunnyPrint.prompt "λ " "%s" " ¬\\nλ > " ++ "\"" ++ "\n:set prompt-cont \"" ++ FunnyPrint.prompt2 "λ" "" " | " ++ "\""))
+:def nocolor (\_ -> return ":set -interactive-print=print\n:set prompt \"%s> \"\n:set prompt-cont \"%s| \"")
 
 :color
 ```


### PR DESCRIPTION
Since GHC 8.2.0 `prompt2` was renamed to `prompt-cont`.
And many distributions already ship 8.2.0 or newer by default nowadays: https://repology.org/project/ghc/versions